### PR TITLE
Add CORS header

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 from random import Random
 from flask import (Flask, request)
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app)
 
 
 @app.route("/random/<random_seed>/choice")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3==1.17.61
 botocore==1.20.61
 click==7.1.2
 Flask==1.1.2
+flask-cors==3.0.10
 greenlet==1.0.0
 itsdangerous==1.1.0
 Jinja2==2.11.3


### PR DESCRIPTION
This PR adds:
```
Access-Control-Allow-Origin: *
```
to the response.

Internal Systems had a candidate who submitted a browser based solution to tic-tac-toe. They had CORS issues since calls to the API were being made client side.
They were able to work around the issue by proxying the request but I think we should remove this obstacle for any future browser based submissions.